### PR TITLE
Refactor SOAP actions in a new .rs file

### DIFF
--- a/src/get_report.rs
+++ b/src/get_report.rs
@@ -1,39 +1,10 @@
-use std::io::Read;
-use base64::engine::general_purpose::STANDARD;
-use base64::Engine;
-use flate2::bufread::GzDecoder;
 use crate::get_xml_by_report::get_xml;
+use crate::soap_operations::{send_soap_request, process_soap_response};
 
 pub fn get_report(url: &str, username: &str, password: &str, report_path: &str, output_format: &str, params: Vec<(&str, String)>)
                   -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let client = reqwest::blocking::Client::new();
     let body = get_xml(report_path, output_format, params);
-
-    let res = client
-        .post(url)
-        .header("Content-Type", "text/xml")
-        .header("SOAPAction", "runReport")
-        .header("Authorization", format!("Basic {}", STANDARD.encode(format!("{}:{}", username, password))))
-        .body(body)
-        .send()?;
-
-    let body = res.bytes()?;
-
-    let mut d = GzDecoder::new(&body[..]);
-    let mut decompressed_body = Vec::new();
-    d.read_to_end(&mut decompressed_body)?;
-
-    let decompressed_body = std::str::from_utf8(&decompressed_body)?;
-    println!("{:?}", decompressed_body);
-    let doc = roxmltree::Document::parse(&decompressed_body)?;
-    let node = doc.root_element();
-    let _ns = node.lookup_namespace_uri(None);
-    let mut result = Vec::new();
-    for elem in node.descendants() {
-        if elem.has_tag_name("reportBytes") {
-            let text = elem.text().unwrap();
-            result = STANDARD.decode(text)?;
-        }
-    }
+    let decompressed_body = send_soap_request(url, username, password, body)?;
+    let result = process_soap_response(decompressed_body)?;
     Ok(result)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod get_report;
 mod get_xml_by_report;
 mod save_to_db;
+mod soap_operations;
+
 use crate::get_report::get_report;
 use crate::save_to_db::save_to_db;
 use dotenv::dotenv;

--- a/src/soap_operations.rs
+++ b/src/soap_operations.rs
@@ -1,0 +1,42 @@
+use std::io::Read;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use flate2::bufread::GzDecoder;
+use reqwest::blocking::Client;
+use roxmltree::Document;
+
+pub fn send_soap_request(url: &str, username: &str, password: &str, body: String) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let client = Client::new();
+
+    let res = client
+        .post(url)
+        .header("Content-Type", "text/xml")
+        .header("SOAPAction", "runReport")
+        .header("Authorization", format!("Basic {}", STANDARD.encode(format!("{}:{}", username, password))))
+        .body(body)
+        .send()?;
+
+    let body = res.bytes()?;
+
+    let mut d = GzDecoder::new(&body[..]);
+    let mut decompressed_body = Vec::new();
+    d.read_to_end(&mut decompressed_body)?;
+
+    Ok(decompressed_body)
+}
+
+pub fn process_soap_response(decompressed_body: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let decompressed_body = std::str::from_utf8(&decompressed_body)?;
+    println!("{:?}", decompressed_body);
+    let doc = Document::parse(&decompressed_body)?;
+    let node = doc.root_element();
+    let _ns = node.lookup_namespace_uri(None);
+    let mut result = Vec::new();
+    for elem in node.descendants() {
+        if elem.has_tag_name("reportBytes") {
+            let text = elem.text().unwrap();
+            result = STANDARD.decode(text)?;
+        }
+    }
+    Ok(result)
+}


### PR DESCRIPTION
Fixes #7

Refactor SOAP operations into a new file `src/soap_operations.rs`.

* **Add `src/soap_operations.rs`**:
  - Create functions `send_soap_request` and `process_soap_response` to handle SOAP requests and responses.
* **Modify `src/get_report.rs`**:
  - Remove SOAP request and response handling logic.
  - Call functions in `src/soap_operations.rs` for SOAP operations.
* **Modify `src/main.rs`**:
  - Include the new module `soap_operations`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zlovtnik/oracle-bip-client/pull/8?shareId=9c6bc4e0-1ccb-4c40-bf2a-328360b859cf).